### PR TITLE
Slight improvement

### DIFF
--- a/content/en-us/build/developer/fat-contract-tutorial.md
+++ b/content/en-us/build/developer/fat-contract-tutorial.md
@@ -47,6 +47,7 @@ The following toolchains are needed:
         - or download the [release](https://github.com/WebAssembly/binaryen/releases/tag/version_105) and put it under your `$PATH`
     - Install dylint-link toolchain: `cargo install cargo-dylint dylint-link` 
     - Install contract toolchain: `cargo install cargo-contract --force`
+    - For macOS M1 chip users: `rustup component add rust-src --toolchain nightly-aarch64-apple-darwin`
 - Install frontend toolchain
     - Node.js (>=v16), follow the [official tutorial](https://nodejs.org/en/download/package-manager/)
     - Yarn (v1): `npm install --global yarn`

--- a/content/en-us/build/developer/fat-contract-tutorial.md
+++ b/content/en-us/build/developer/fat-contract-tutorial.md
@@ -45,6 +45,7 @@ The following toolchains are needed:
         - Homebrew for macOS: `brew install binaryen`
         - Apt for Ubuntu: `sudo apt install binaryen`
         - or download the [release](https://github.com/WebAssembly/binaryen/releases/tag/version_105) and put it under your `$PATH`
+    - Install dylint-link toolchain: `cargo install cargo-dylint dylint-link` 
     - Install contract toolchain: `cargo install cargo-contract --force`
 - Install frontend toolchain
     - Node.js (>=v16), follow the [official tutorial](https://nodejs.org/en/download/package-manager/)


### PR DESCRIPTION
Installation on Mac OS fails without the Rust dylint-link toolchain pre installed before installing the contract toolchain.

I suggest adding it to the requirements. Else the following error is shown:

<img width="1181" alt="Screenshot 2022-04-25 at 16 46 23" src="https://user-images.githubusercontent.com/37558304/165115363-26204dcd-14ec-474a-b967-0e798f8a97d4.png">

