### PR TITLE
Tokenomics slash part fix.

### DIFF
--- a/content/en-us/general/phala-network/tokenomics.md
+++ b/content/en-us/general/phala-network/tokenomics.md
@@ -206,7 +206,7 @@ Potential parameters:
 
 ### Slash rules
 
-The slash rules for miners are defined below. Note that currently only the Level 1 slash is currently implemented.
+The slash rules for miners are defined below. No slash rules have been implemented at the moment, but will start in the near future.
 
 | Severity | Fault                               | Punishment                                |
 | -------- | ----------------------------------- | ----------------------------------------- |


### PR DESCRIPTION
The wiki shows that slash rule Level 1 is implemented, but actually, no rules have been deployed. So I change it